### PR TITLE
rename registrations collections to registrations_v2

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -4,7 +4,7 @@ package constants
 const FirebaseURL = "https://erouska-key-server-dev.firebaseio.com/"
 
 //CollectionRegistrations Name of the collection.
-const CollectionRegistrations = "registrations"
+const CollectionRegistrations = "registrations_v2"
 
 //CollectionDailyNotificationAttemptsEhrid Name of the collection.
 const CollectionDailyNotificationAttemptsEhrid = "dailyNotificationAttemptsEhrid"


### PR DESCRIPTION
closes #48 
I don't think we need to migrate any data (that would be a bit more complicated). We just switch to a new empty collection. 