### PR TITLE
add 'Pub/Sub Publisher' role to register-notification SA

### DIFF
--- a/terraform/modules/erouska/coviddata.tf
+++ b/terraform/modules/erouska/coviddata.tf
@@ -34,6 +34,7 @@ locals {
   registernotification_roles = [
     "roles/cloudfunctions.serviceAgent",
     "roles/datastore.user",
+    "roles/pubsub.publisher",
   ]
 
   registernotificationaftermath_roles = [


### PR DESCRIPTION
it seems that register-notification is not able to publish messages with the basic CF roles. Tested on dev:

```
gcloud auth list
                           Credentialed Accounts
ACTIVE  ACCOUNT
*       register-notification@erouska-key-server-dev.iam.gserviceaccount.com
gcloud pubsub topics publish notification-registered --message="hello"
ERROR: (gcloud.pubsub.topics.publish) PERMISSION_DENIED: User not authorized to perform this action.
```

after adding `Pub/Sub Publisher`

```
gcloud pubsub topics publish notification-registered --message="hello"
messageIds:
- '1572270711743739'
```