### PR TITLE
Draft: align IAM settings with the current state

### DIFF
--- a/terraform/modules/erouska/coviddata.tf
+++ b/terraform/modules/erouska/coviddata.tf
@@ -34,7 +34,6 @@ locals {
   registernotification_roles = [
     "roles/cloudfunctions.serviceAgent",
     "roles/datastore.user",
-    "roles/pubsub.publisher",
   ]
 
   registernotificationaftermath_roles = [

--- a/terraform/modules/erouska/notification.tf
+++ b/terraform/modules/erouska/notification.tf
@@ -1,3 +1,17 @@
 resource "google_pubsub_topic" "notification-registered" {
   name = "notification-registered"
 }
+
+resource "google_pubsub_topic_iam_member" "notification-registered-registernotification" {
+  project = google_pubsub_topic.notification-registered.project
+  topic   = google_pubsub_topic.notification-registered.name
+  role    = "roles/pubsub.admin"
+  member  = "serviceAccount:${google_service_account.registernotification.email}"
+}
+
+resource "google_pubsub_topic_iam_member" "notification-registered-registernotificationaftermath" {
+  project = google_pubsub_topic.notification-registered.project
+  topic   = google_pubsub_topic.notification-registered.name
+  role    = "roles/pubsub.admin"
+  member  = "serviceAccount:${google_service_account.registernotificationaftermath.email}"
+}


### PR DESCRIPTION
latest changes I've applied manually during the investigation. Dev can be applied as it is, Prod needs to be imported:

```bash
terraform import google_pubsub_topic_iam_member.notification-registered-registernotificationaftermath "projects/daring-leaf-272223/topics/notification-registered roles/pubsub.admin serviceAccount:reg-notification-aftermath@daring-leaf-272223.iam.gserviceaccount.com"
```

and

```bash
terraform import google_pubsub_topic_iam_member.notification-registered-registernotification "projects/daring-leaf-272223/topics/notification-registered roles/pubsub.admin serviceAccount:register-notification@daring-leaf-272223.iam.gserviceaccount.com"
```