### PR TITLE
SecretsManagerClient impl

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/covid19cz/erouska-backend
 go 1.13
 
 require (
+	cloud.google.com/go v0.56.0
 	cloud.google.com/go/firestore v1.2.0
 	cloud.google.com/go/pubsub v1.3.1
 	firebase.google.com/go v3.13.0+incompatible

--- a/internal/secrets/secrets.go
+++ b/internal/secrets/secrets.go
@@ -1,0 +1,75 @@
+package secrets
+
+import (
+	secretmanager "cloud.google.com/go/secretmanager/apiv1"
+	"context"
+	"fmt"
+	"github.com/covid19cz/erouska-backend/internal/constants"
+	"github.com/covid19cz/erouska-backend/internal/logging"
+	secretmanagerpb "google.golang.org/genproto/googleapis/cloud/secretmanager/v1"
+	"log"
+	"os"
+)
+
+//SecretsManagerClient -_-
+var SecretsManagerClient *secretmanager.Client
+var projectID string
+
+func init() {
+	ctx := context.Background()
+
+	projectID = constants.ProjectID
+	id, exists := os.LookupEnv("PROJECT_ID")
+	if exists {
+		projectID = id
+	}
+
+	if projectID == "NOOP" {
+		log.Printf("Mocking PubSub")
+		return
+	}
+
+	var err error
+	SecretsManagerClient, err = secretmanager.NewClient(ctx)
+	if err != nil {
+		log.Fatalf("secretmanager.NewClient: %v", err)
+	}
+}
+
+//Manager is an abstraction over PubSub
+type Manager interface {
+	Get(name string) ([]byte, error)
+}
+
+//Client Real Secrets Manager client.
+type Client struct{}
+
+//Get Gets value of specified secret.
+func (c Client) Get(name string) ([]byte, error) {
+	ctx := context.Background()
+	var logger = logging.FromContext(ctx)
+
+	logger.Debugf("Accessing secret '%v'", name)
+
+	var req = secretmanagerpb.AccessSecretVersionRequest{
+		Name: fmt.Sprintf("projects/%v/secrets/%v/versions/latest", projectID, name),
+	}
+
+	secret, err := SecretsManagerClient.AccessSecretVersion(ctx, &req)
+	if err != nil {
+		log.Fatalf("Failed to get secret value: %v", err)
+		return nil, err
+	}
+
+	logger.Debugf("Got secret '%v': %+v", name, secret)
+
+	return secret.GetPayload().GetData(), nil
+}
+
+//MockClient NOOP Secrets Manager client.
+type MockClient struct{}
+
+//Get Gets value of specified secret.
+func (c MockClient) Get(name string) ([]byte, error) {
+	return []byte("mock42"), nil
+}


### PR DESCRIPTION
Example usage:
```go
func JendaSecretsTest(w http.ResponseWriter, r *http.Request) {
	ctx := r.Context()
	logger := logging.FromContext(ctx)

	secretsClient := secrets.Client{}

	secret, err := secretsClient.Get("jenda-test")

	if err != nil {
		logger.Errorf("Error while getting secret: %v", err)
		http.Error(w, fmt.Sprintf("Error while getting secret: %v", err), 500)
	}

	_, err = w.Write(secret)
	if err != nil {
		logger.Errorf("Error while sending response: %v", err)
	}
}
```

The function has to have `roles/secretmanager.secretAccessor` permission to be able to read the secret.