### PR TITLE
terraform: fix preparemetrics IAM role

### DIFF
--- a/terraform/modules/erouska/coviddata.tf
+++ b/terraform/modules/erouska/coviddata.tf
@@ -19,7 +19,7 @@ locals {
     "roles/cloudfunctions.serviceAgent",
     "roles/datastore.viewer",
     "roles/firebasedatabase.viewer",
-    "roles/monitoring.timeSeries.list"
+    "roles/monitoring.viewer"
   ]
 
   downloadmetrics_roles = [


### PR DESCRIPTION
```    
"roles/monitoring.timeSeries.list"
```
does not exist
you are mixing up roles and permissions