### PR TITLE
Download per partes

### DIFF
--- a/builders/deploy.yaml
+++ b/builders/deploy.yaml
@@ -173,7 +173,7 @@ steps:
       - deploy
       - EfgsDownloadKeys
       - --source=.
-      - --trigger-topic=efgs-download-keys
+      - --trigger-http
       - --region=europe-west1
       - --runtime=go113
       - --memory=128
@@ -182,7 +182,7 @@ steps:
       - --set-env-vars=PROJECT_ID=${PROJECT_ID}
       - --set-env-vars=EFGS_ENV=${_EFGS_ENV},EFGS_EXTENDED_LOGGING=${_EFGS_EXTENDED_LOGGING}
       - --set-env-vars=MAX_INTERVAL_AGE_ON_PUBLISH=${_MAX_INTERVAL_AGE_ON_PUBLISH},MAX_KEYS_ON_PUBLISH=${_MAX_KEYS_ON_PUBLISH},MAX_SAME_START_INTERVAL_KEYS=${_MAX_SAME_START_INTERVAL_KEYS}
-      - --set-env-vars=KEY_SERVER_URL=${_KEY_SERVER_URL},VERIFICATION_SERVER_ADMIN_URL=${_VERIFICATION_SERVER_ADMIN_URL},VERIFICATION_SERVER_DEVICE_URL=${_VERIFICATION_SERVER_DEVICE_URL}
+      - --set-env-vars=EFGS_REDIS_ADDR=${_EFGS_REDIS_ADDR}
   - name: "gcr.io/cloud-builders/gcloud"
     waitFor: ["-"]
     args:
@@ -199,6 +199,22 @@ steps:
       - --set-env-vars=PROJECT_ID=${PROJECT_ID}
       - --set-env-vars=EFGS_ENV=${_EFGS_ENV},EFGS_EXTENDED_LOGGING=${_EFGS_EXTENDED_LOGGING}
       - --set-env-vars=MAX_INTERVAL_AGE_ON_PUBLISH=${_MAX_INTERVAL_AGE_ON_PUBLISH},MAX_KEYS_ON_PUBLISH=${_MAX_KEYS_ON_PUBLISH},MAX_SAME_START_INTERVAL_KEYS=${_MAX_SAME_START_INTERVAL_KEYS}
+  - name: "gcr.io/cloud-builders/gcloud"
+    waitFor: ["-"]
+    args:
+      - functions
+      - deploy
+      - EfgsImportKeys
+      - --source=.
+      - --trigger-topic=efgs-import-keys
+      - --region=europe-west1
+      - --runtime=go113
+      - --memory=128
+      - --timeout=540s
+      - --service-account=efgs-import-keys@${PROJECT_ID}.iam.gserviceaccount.com
+      - --set-env-vars=PROJECT_ID=${PROJECT_ID}
+      - --set-env-vars=EFGS_ENV=${_EFGS_ENV},EFGS_EXTENDED_LOGGING=${_EFGS_EXTENDED_LOGGING}
+      - --set-env-vars=MAX_KEYS_ON_PUBLISH=${_MAX_KEYS_ON_PUBLISH}
       - --set-env-vars=KEY_SERVER_URL=${_KEY_SERVER_URL},VERIFICATION_SERVER_ADMIN_URL=${_VERIFICATION_SERVER_ADMIN_URL},VERIFICATION_SERVER_DEVICE_URL=${_VERIFICATION_SERVER_DEVICE_URL}
   - name: 'gcr.io/cloud-builders/gcloud'
     waitFor: ['-']

--- a/functions.go
+++ b/functions.go
@@ -2,8 +2,6 @@ package functions
 
 import (
 	"context"
-	"github.com/covid19cz/erouska-backend/internal/pubsub"
-
 	"github.com/covid19cz/erouska-backend/internal/functions/changepushtoken"
 	"github.com/covid19cz/erouska-backend/internal/functions/coviddata"
 	"github.com/covid19cz/erouska-backend/internal/functions/efgs"
@@ -12,6 +10,7 @@ import (
 	"github.com/covid19cz/erouska-backend/internal/functions/publishkeys"
 	"github.com/covid19cz/erouska-backend/internal/functions/registerehrid"
 	"github.com/covid19cz/erouska-backend/internal/functions/registernotification"
+	"github.com/covid19cz/erouska-backend/internal/pubsub"
 
 	"net/http"
 )
@@ -80,14 +79,19 @@ func EfgsUploadKeys(w http.ResponseWriter, r *http.Request) {
 	efgs.UploadBatch(w, r)
 }
 
-// EfgsDownloadKeys downloads EFGS keys batch
-func EfgsDownloadKeys(ctx context.Context, m pubsub.Message) error {
-	return efgs.DownloadAndSaveKeys(ctx, m)
+// EfgsDownloadKeys downloads EFGS keys - most recent batch
+func EfgsDownloadKeys(w http.ResponseWriter, r *http.Request) {
+	efgs.DownloadAndSaveKeys(w, r)
 }
 
 // EfgsDownloadYesterdaysKeys downloads EFGS keys batch from whole yesterday
 func EfgsDownloadYesterdaysKeys(w http.ResponseWriter, r *http.Request) {
 	efgs.DownloadAndSaveYesterdaysKeys(w, r)
+}
+
+//EfgsImportKeys Imports given keys
+func EfgsImportKeys(ctx context.Context, m pubsub.Message) error {
+	return efgs.ImportKeysToKeyServer(ctx, m)
 }
 
 //EfgsRemoveOldKeys handler.

--- a/go.mod
+++ b/go.mod
@@ -10,12 +10,14 @@ require (
 	github.com/GoogleCloudPlatform/cloudsql-proxy v1.18.0
 	github.com/avast/retry-go v2.6.0+incompatible
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
-	github.com/go-pg/pg/v10 v10.3.2
+	github.com/go-pg/pg/v10 v10.7.0
+	github.com/go-redis/redis/v8 v8.4.0
+	github.com/go-redsync/redsync/v4 v4.0.3
 	github.com/golang/gddo v0.0.0-20200715224205-051695c33a3f
 	github.com/golang/protobuf v1.4.3
 	github.com/google/exposure-notifications-server v0.16.0
 	github.com/google/exposure-notifications-verification-server v0.16.0
-	github.com/google/go-cmp v0.5.2
+	github.com/google/go-cmp v0.5.3
 	github.com/hashicorp/go-retryablehttp v0.6.8
 	github.com/leanovate/gopter v0.2.9
 	github.com/sethvargo/go-envconfig v0.3.2

--- a/go.sum
+++ b/go.sum
@@ -205,8 +205,10 @@ github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QH
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/census-instrumentation/opencensus-proto v0.3.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/centrify/cloud-golang-sdk v0.0.0-20190214225812-119110094d0f/go.mod h1:C0rtzmGXgN78pYR0tGJFhtHgkbAs0lIbHwkB81VxDQE=
+github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.0/go.mod h1:dgIUBU3pDso/gPgZ1osOZ0iQf77oPR28Tjxl5dIMyVM=
+github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chris-ramon/douceur v0.2.0/go.mod h1:wDW5xjJdeoMm1mRt4sD4c/LbF/mWdEpRXQKjTR8nIBE=
 github.com/chrismalek/oktasdk-go v0.0.0-20181212195951-3430665dfaa0/go.mod h1:5d8DqS60xkj9k3aXfL3+mXBH0DPYO0FQjcKosxl+b/Q=
@@ -262,6 +264,8 @@ github.com/denisenkom/go-mssqldb v0.0.0-20200620013148-b91950f658ec/go.mod h1:xb
 github.com/denisenkom/go-mssqldb v0.0.0-20200831201914-36b6ff1bbc10/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27NDyej4t/EjAShU=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dhui/dktest v0.3.2/go.mod h1:l1/ib23a/CmxAe7yixtrYPc8Iy90Zy2udyaHINM5p58=
 github.com/dimchansky/utfbom v1.1.0/go.mod h1:rO41eb7gLfo8SF1jd9F8HplJm1Fewwi4mQvIirEdv+8=
@@ -345,6 +349,8 @@ github.com/go-openapi/spec v0.0.0-20160808142527-6aced65f8501/go.mod h1:J8+jY1nA
 github.com/go-openapi/swag v0.0.0-20160704191624-1d0bd113de87/go.mod h1:DXUve3Dpr1UfpPtxFw+EFuQ41HhCWZfha5jSVRG7C7I=
 github.com/go-pg/pg/v10 v10.3.2 h1:2GgewrvOE3G0eQH5V6NhAx5vzI+1If0cupnF9Ls3znY=
 github.com/go-pg/pg/v10 v10.3.2/go.mod h1:wY0cRYyO1JfUXBF2XjkbnNvhce3WyunFDhEvZXnHbP0=
+github.com/go-pg/pg/v10 v10.7.0 h1:Wzzcha23ruGpPh1PP+KP6+k6EDB1Fuzi/XPnu2PDZwI=
+github.com/go-pg/pg/v10 v10.7.0/go.mod h1:UsDYtA+ihbBNX1OeIvDejxkL4RXzL3wsZYoEv5NUEqM=
 github.com/go-pg/zerochecker v0.2.0 h1:pp7f72c3DobMWOb2ErtZsnrPaSvHd2W4o9//8HtF4mU=
 github.com/go-pg/zerochecker v0.2.0/go.mod h1:NJZ4wKL0NmTtz0GKCoJ8kym6Xn/EQzXRl2OnAe7MmDo=
 github.com/go-playground/assert/v2 v2.0.1/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
@@ -354,6 +360,15 @@ github.com/go-playground/universal-translator v0.17.0 h1:icxd5fm+REJzpZx7ZfpaD87
 github.com/go-playground/universal-translator v0.17.0/go.mod h1:UkSxE5sNxxRwHyU+Scu5vgOQjsIJAF8j9muTVoKLVtA=
 github.com/go-playground/validator/v10 v10.2.0/go.mod h1:uOYAAleCW8F/7oMFd6aG0GOhaH6EGOAJShg8Id5JGkI=
 github.com/go-playground/validator/v10 v10.3.0/go.mod h1:uOYAAleCW8F/7oMFd6aG0GOhaH6EGOAJShg8Id5JGkI=
+github.com/go-redis/redis v6.15.9+incompatible h1:K0pv1D7EQUjfyoMql+r/jZqCLizCGKFlFgcHWWmHQjg=
+github.com/go-redis/redis v6.15.9+incompatible/go.mod h1:NAIEuMOZ/fxfXJIrKDQDz8wamY7mA7PouImQ2Jvg6kA=
+github.com/go-redis/redis/v7 v7.4.0/go.mod h1:JDNMw23GTyLNC4GZu9njt15ctBQVn7xjRfnwdHj/Dcg=
+github.com/go-redis/redis/v8 v8.1.1/go.mod h1:ysgGY09J/QeDYbu3HikWEIPCwaeOkuNoTgKayTEaEOw=
+github.com/go-redis/redis/v8 v8.4.0 h1:J5NCReIgh3QgUJu398hUncxDExN4gMOHI11NVbVicGQ=
+github.com/go-redis/redis/v8 v8.4.0/go.mod h1:A1tbYoHSa1fXwN+//ljcCYYJeLmVrwL9hbQN45Jdy0M=
+github.com/go-redsync/redsync v1.4.2 h1:KADEZ2rlaHMZWnlkthQCxfGP+8ZWwJLiSjOYN3mntKA=
+github.com/go-redsync/redsync/v4 v4.0.3 h1:q2Vxl6el3XbfVr0+z5cjQwvAhHzgTrsf26iuCcbQ/Yc=
+github.com/go-redsync/redsync/v4 v4.0.3/go.mod h1:QBOJAs1k8O6Eyrre4a++pxQgHe5eQ+HF56KuTVv+8Bs=
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
@@ -423,6 +438,7 @@ github.com/golang/snappy v0.0.0-20170215233205-553a64147049/go.mod h1:/XxbfmMg8l
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.2/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/gomodule/redigo v1.8.2/go.mod h1:P9dn9mFrCBvWhGE1wpxx6fgq7BAeLBk+UUUzlpkBYO0=
 github.com/gonum/blas v0.0.0-20181208220705-f22b278b28ac/go.mod h1:P32wAyui1PQ58Oce/KYkOqQv8cVw1zAapXOl+dRFGbc=
 github.com/gonum/floats v0.0.0-20181209220543-c233463c7e82/go.mod h1:PxC8OnwL11+aosOB5+iEPoV3picfs8tUpkVd0pDo+Kg=
 github.com/gonum/internal v0.0.0-20181124074243-f884aa714029/go.mod h1:Pu4dmpkhSyOzRwuXkOgAvijx4o+4YMUJJo9OvPYMkks=
@@ -447,6 +463,8 @@ github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.3 h1:x95R7cp+rSeeqAMI2knLtQ0DKlaBhv2NrtrOvafPHRo=
+github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-metrics-stackdriver v0.2.0/go.mod h1:KLcPyp3dWJAFD+yHisGlJSZktIsTjb50eB72U2YZ9K0=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
@@ -520,6 +538,7 @@ github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyN
 github.com/hashicorp/consul/sdk v0.3.0/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
 github.com/hashicorp/consul/sdk v0.4.0/go.mod h1:fY08Y9z5SvJqevyZNy6WWPXiG3KwBPAvlcdx16zZ0fM=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-bindata v3.0.8-0.20180209072458-bf7910af8997+incompatible/go.mod h1:+IrDq36jUYG0q6TsDY9uO2p77C8f8S5y+RbYHr2UI+U=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
@@ -546,6 +565,7 @@ github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iP
 github.com/hashicorp/go-msgpack v0.5.5/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
 github.com/hashicorp/go-msgpack v1.1.5/go.mod h1:gWVc3sv/wbDmR3rQsj1CAktEZzoz1YNK9NfGLXJ69/4=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
+github.com/hashicorp/go-multierror v1.1.0 h1:B9UzwGQJehnUY1yNrnwREHc3fGbC2xefo8g4TbElacI=
 github.com/hashicorp/go-multierror v1.1.0/go.mod h1:spPvp8C1qA32ftKqdAHm4hHTbPw+vmowP0z+KUhOZdA=
 github.com/hashicorp/go-plugin v1.0.0/go.mod h1:++UyYGoz3o5w9ZzAdZxtQKrWWP+iqPBn3cQptSMzBuY=
 github.com/hashicorp/go-plugin v1.0.1/go.mod h1:++UyYGoz3o5w9ZzAdZxtQKrWWP+iqPBn3cQptSMzBuY=
@@ -873,6 +893,7 @@ github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108
 github.com/onsi/ginkgo v1.13.0/go.mod h1:+REjRxOmWfHCjfv9TTWB1jD1Frx4XydAD3zm1lskyM0=
 github.com/onsi/ginkgo v1.14.1 h1:jMU0WaQrP0a/YAEq8eJmJKjBoMs+pClEr1vDMlM/Do4=
 github.com/onsi/ginkgo v1.14.1/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
+github.com/onsi/ginkgo v1.14.2/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v0.0.0-20190113212917-5533ce8a0da3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
@@ -883,6 +904,7 @@ github.com/onsi/gomega v1.9.0/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoT
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.10.2 h1:aY/nuoWlKJud2J6U0E3NWsjlg+0GtwXxgEqthRdzlcs=
 github.com/onsi/gomega v1.10.2/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
+github.com/onsi/gomega v1.10.3/go.mod h1:V9xEwhxec5O8UDM77eCW8vLymOMltsqPVYWrpDsH8xc=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
 github.com/opencensus-integrations/redigo v2.0.1+incompatible/go.mod h1:iH5qq3BZppLeyPZP0Hy2qffpbcppAl58otmaERGeJaQ=
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
@@ -1065,6 +1087,7 @@ github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stvp/tempredis v0.0.0-20181119212430-b82af8480203/go.mod h1:oqN97ltKNihBbwlX8dLpwxCl3+HnXKV/R0e+sRLd9C8=
 github.com/tencentcloud/tencentcloud-sdk-go v3.0.171+incompatible/go.mod h1:0PfYow01SHPMhKY31xa+EFz2RStxIqj6JFAJS+IkCi4=
 github.com/tidwall/pretty v0.0.0-20180105212114-65a9db5fad51/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
@@ -1090,8 +1113,12 @@ github.com/vmihailenco/bufpool v0.1.11/go.mod h1:AFf/MOy3l2CFTKbxwt0mp2MwnqjNEs5
 github.com/vmihailenco/msgpack/v4 v4.3.11/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/msgpack/v5 v5.0.0-beta.1 h1:d71/KA0LhvkrJ/Ok+Wx9qK7bU8meKA1Hk0jpVI5kJjk=
 github.com/vmihailenco/msgpack/v5 v5.0.0-beta.1/go.mod h1:xlngVLeyQ/Qi05oQxhQ+oTuqa03RjMwMfk/7/TCs+QI=
+github.com/vmihailenco/msgpack/v5 v5.0.0 h1:nCaMMPEyfgwkGc/Y0GreJPhuvzqCqW+Ufq5lY7zLO2c=
+github.com/vmihailenco/msgpack/v5 v5.0.0/go.mod h1:HVxBVPUK/+fZMonk4bi1islLa8V3cfnBug0+4dykPzo=
 github.com/vmihailenco/tagparser v0.1.1 h1:quXMXlA39OCbd2wAdTsGDlK9RkOk6Wuw+x37wVyIuWY=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
+github.com/vmihailenco/tagparser v0.1.2 h1:gnjoVuB/kljJ5wICEEOpx98oXMWPLj22G67Vbd1qPqc=
+github.com/vmihailenco/tagparser v0.1.2/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
 github.com/xanzy/go-gitlab v0.15.0/go.mod h1:8zdQa/ri1dfn8eS3Ir1SyfvOKlw7WBJ8DVThkpGiXrs=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=
 github.com/xdg/stringprep v1.0.0/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=
@@ -1126,8 +1153,12 @@ go.opencensus.io v0.22.4 h1:LYy1Hy3MJdrCdMwwzxA/dRok4ejH+RwNGbuoD9fCjto=
 go.opencensus.io v0.22.4/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opencensus.io v0.22.5 h1:dntmOdLpSpHlVqbW5Eay97DelsZHe+55D+xC6i0dDS0=
 go.opencensus.io v0.22.5/go.mod h1:5pWMHQbX5EPX2/62yrJeAkowc+lfs/XD7Uxpq3pI6kk=
+go.opentelemetry.io v0.1.0 h1:EANZoRCOP+A3faIlw/iN6YEWoYb1vleZRKm1EvH8T48=
+go.opentelemetry.io/otel v0.11.0/go.mod h1:G8UCk+KooF2HLkgo8RHX9epABH/aRGYET7gQOqBVdB0=
 go.opentelemetry.io/otel v0.12.0 h1:bwWaPd/h2q+U6KdKaAiOS5GLwOMd1LDt9iNaeyIoAI8=
 go.opentelemetry.io/otel v0.12.0/go.mod h1:dlSNewoRYikTkotEnxdmuBHgzT+k/idJSfDv/FxEnOY=
+go.opentelemetry.io/otel v0.14.0 h1:YFBEfjCk9MTjaytCNSUkp9Q8lF7QJezA06T71FbQxLQ=
+go.opentelemetry.io/otel v0.14.0/go.mod h1:vH5xEuwy7Rts0GNtsCW3HYQoZDY+OmBJ6t1bFGGlxgw=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.5.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
@@ -1180,6 +1211,8 @@ golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897 h1:pLI5jrR7OSLijeIDcmRxNmw2api+jEfxLoykJVice/E=
 golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20201117144127-c1f2f97bffc9 h1:phUcVbl53swtrUN8kQEXFhUxPlIlWyBfKmidCu7P95o=
+golang.org/x/crypto v0.0.0-20201117144127-c1f2f97bffc9/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
@@ -1267,6 +1300,7 @@ golang.org/x/net v0.0.0-20200904194848-62affa334b73/go.mod h1:/O7V0waA8r7cgGh81R
 golang.org/x/net v0.0.0-20200923182212-328152dc79b1/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200925080053-05aa5d4ee321 h1:lleNcKRbcaC8MqgLwghIkzZ2JBQAb7QQ9MiwRt1BisA=
 golang.org/x/net v0.0.0-20200925080053-05aa5d4ee321/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
+golang.org/x/net v0.0.0-20201006153459-a7d1128ccaa0/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201026091529-146b70c837a4/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b h1:uwuIcX0g4Yl1NC5XAz37xsr2lTtcqevgzYNVt49waME=
@@ -1373,6 +1407,9 @@ golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201015000850-e3ed0017c211/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201109165425-215b40eba54c h1:+B+zPA6081G5cEb2triOIJpcvSW4AYzmIyWAqMn2JAc=
 golang.org/x/sys v0.0.0-20201109165425-215b40eba54c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68 h1:nxC68pudNYkKU6jWhgrqdreuFiOQWj1Fs7T3VrH4Pjw=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=

--- a/internal/functions/efgs/api/structs.go
+++ b/internal/functions/efgs/api/structs.go
@@ -85,6 +85,12 @@ type BatchDownloadParams struct {
 	BatchTag string `json:"batchTag"`
 }
 
+//BatchImportParams Struct for transferring downloaded keys
+type BatchImportParams struct {
+	HAID string      `json:"haid"`
+	Keys ExpKeyBatch `json:"keys"`
+}
+
 //DiagnosisKeyWrapper map json response from EFGS to local DiagnosisKey structure
 type DiagnosisKeyWrapper struct {
 	tableName                  struct{}  `pg:"diagnosis_keys,alias:dk"`

--- a/internal/functions/efgs/configuration.go
+++ b/internal/functions/efgs/configuration.go
@@ -150,14 +150,9 @@ func loadDownloadConfig(ctx context.Context) (*downloadConfig, error) {
 	config.URL = url
 	config.NBTLSPair = nbtlsPair
 	config.Client = client
-
-	publishConfig, err := loadPublishConfig(ctx)
-	if err != nil {
-		logger.Debugf("Could not load publish config: %v", err)
-		return nil, err
-	}
-
-	config.PublishConfig = publishConfig
+	config.PubSubClient = pubsub.Client{}
+	config.MutexManager = redismutex.ClientImpl{}
+	config.RedisClient = redis.ClientImpl{}
 
 	return &config, nil
 }

--- a/internal/functions/efgs/constants/constants.go
+++ b/internal/functions/efgs/constants/constants.go
@@ -1,0 +1,10 @@
+package constants
+
+//TopicNameImportKeys Topic for enqueuing keys to be imported.
+const TopicNameImportKeys = "efgs-import-keys"
+
+//MutexNameDownloadAndSaveKeys Name for mutex for EFGS keys downloading.
+const MutexNameDownloadAndSaveKeys = "download-and-save-keys"
+
+//RedisKeyNextBatch Key for next download batch metadata.
+const RedisKeyNextBatch = "nextDownloadBatch"

--- a/internal/functions/efgs/redis/redis.go
+++ b/internal/functions/efgs/redis/redis.go
@@ -1,0 +1,83 @@
+package redis
+
+import (
+	"context"
+	"fmt"
+	"github.com/covid19cz/erouska-backend/internal/logging"
+	redisclient "github.com/go-redis/redis/v8"
+	"os"
+	"sync"
+	"time"
+)
+
+var redisClient *Connection
+var ctx context.Context
+
+type lazyConnection func() *redisclient.Client
+
+//Connection Contains lazy Redis connection
+type Connection struct {
+	inner lazyConnection
+}
+
+func init() {
+	ctx = context.Background()
+
+	connect := func() *redisclient.Client {
+		logger := logging.FromContext(ctx).Named("efgs.redis.connect")
+
+		logger.Debug("Connecting to EFGS Redis")
+
+		addr, ok := os.LookupEnv("EFGS_REDIS_ADDR")
+		if !ok {
+			panic("EFGS_REDIS_ADDR env missing")
+		}
+
+		client := redisclient.NewClient(&redisclient.Options{
+			Addr: addr,
+			DB:   0,
+		})
+
+		_, err := client.Ping(ctx).Result()
+		if err != nil {
+			panic(fmt.Sprintf("Connection to Redis failed:%v", err))
+		}
+
+		logger.Debugf("Connected to EFGS Redis at %v", addr)
+
+		return client
+	}
+
+	var conn *redisclient.Client
+	var once sync.Once
+
+	initInner := func() *redisclient.Client {
+		once.Do(func() {
+			conn = connect()
+		})
+		return conn
+	}
+
+	redisClient = &Connection{
+		inner: initInner,
+	}
+}
+
+//Client Redis client abstraction
+type Client interface {
+	Get(key string) (string, error)
+	Set(key string, value interface{}, ttl time.Duration) error
+}
+
+//ClientImpl Real Redis client
+type ClientImpl struct{}
+
+//Get Get value from Redis
+func (r ClientImpl) Get(key string) (string, error) {
+	return redisClient.inner().Get(ctx, key).Result()
+}
+
+//Set Set value to Redis. TLL value 0 means forever.
+func (r ClientImpl) Set(key string, value interface{}, ttl time.Duration) error {
+	return redisClient.inner().Set(ctx, key, value, ttl).Err()
+}

--- a/internal/functions/efgs/redismutex/redis-mutex.go
+++ b/internal/functions/efgs/redismutex/redis-mutex.go
@@ -1,0 +1,90 @@
+package redismutex
+
+import (
+	"context"
+	"fmt"
+	"github.com/covid19cz/erouska-backend/internal/logging"
+	redisclient "github.com/go-redis/redis/v8"
+	"github.com/go-redsync/redsync/v4"
+	"github.com/go-redsync/redsync/v4/redis/goredis/v8"
+	"os"
+	"sync"
+	"time"
+)
+
+var rs *Connection
+var ctx context.Context
+
+type lazyConnection func() *redsync.Redsync
+
+//Connection Contains lazy Redsync connection
+type Connection struct {
+	inner lazyConnection
+}
+
+func init() {
+	ctx = context.Background()
+
+	connect := func() *redsync.Redsync {
+		logger := logging.FromContext(ctx).Named("efgs.redis-mutex.connect")
+
+		logger.Debug("Connecting to EFGS Redis")
+
+		addr, ok := os.LookupEnv("EFGS_REDIS_ADDR")
+		if !ok {
+			panic("EFGS_REDIS_ADDR env missing")
+		}
+
+		client := redisclient.NewClient(&redisclient.Options{
+			Addr: addr,
+			DB:   1, // here it differs from normal Redis client!
+		})
+
+		_, err := client.Ping(ctx).Result()
+		if err != nil {
+			panic(fmt.Sprintf("Connection to Redis failed:%v", err))
+		}
+
+		logger.Debugf("Connected to EFGS Redis at %v", addr)
+
+		return redsync.New(goredis.NewPool(client))
+	}
+
+	var conn *redsync.Redsync
+	var once sync.Once
+
+	initInner := func() *redsync.Redsync {
+		once.Do(func() {
+			conn = connect()
+		})
+		return conn
+	}
+
+	rs = &Connection{
+		inner: initInner,
+	}
+}
+
+//MutexManager Mutex manager over Redis
+type MutexManager interface {
+	Lock(name string) (*redsync.Mutex, error)
+}
+
+//ClientImpl Real Redis mutex client
+type ClientImpl struct{}
+
+//Lock Creates locked mutex
+func (r ClientImpl) Lock(name string) (*redsync.Mutex, error) {
+	logger := logging.FromContext(ctx).Named("efgs.redis-mutex.Lock")
+
+	mutex := rs.inner().NewMutex(name, redsync.WithExpiry(time.Hour)) // expiration of 1 hour is just to be sure
+
+	logger.Debugf("Trying to acquire '%v' exclusive lock", name)
+
+	err := mutex.Lock()
+	if err != nil {
+		return nil, err
+	}
+
+	return mutex, nil
+}

--- a/terraform/modules/erouska/notification.tf
+++ b/terraform/modules/erouska/notification.tf
@@ -6,6 +6,6 @@ resource "google_pubsub_topic" "user-registered" {
   name = "user-registered"
 }
 
-resource "google_pubsub_topic" "efgs-download-keys" {
-  name = "efgs-download-keys"
+resource "google_pubsub_topic" "efgs-import-keys" {
+  name = "efgs-import-keys"
 }


### PR DESCRIPTION
There are two commits present in this PR. I recommend reviewing them one after another.

The first commit adds an implementation of Redis client and Redis-based distributed mutex. The mutex is needed to secure the `DownloadAndSaveKeys` functions run only once a time as it works with some data in the Redis.

The second commit is an implementation of change in downloading - batch that should be downloaded is loaded from Redis, data are published to PubSub (which triggers `EfgsImportKeys` function) and next batch params are saved back to the Redis. This is to:
1. prevent overloading EFGS server, they don't want us to download everything repeatedly (we do it by parts and only once all again, for sure - `DownloadAndSaveYesterdaysKeys`)
1. prevent overloading of Verification server (its rate limit)

`EfgsDownloadKeys` is now triggered with scheduler via HTTP. Its PubSub topic `efgs-download-keys` was removed/replaced by `efgs-import-keys` (which triggers `EfgsImportKeys` function).

Rate limit handling of `EfgsImportKeys` will be done separately in following PR.

Closes #148 