### PR TITLE
chore: align alerting module with upstream

### DIFF
--- a/terraform/prod/verification-server/main.tf
+++ b/terraform/prod/verification-server/main.tf
@@ -37,9 +37,15 @@ module "alerting" {
   source                      = "git::https://github.com/google/exposure-notifications-verification-server.git//terraform/alerting?ref=v0.17.0"
   verification-server-project = var.project
   monitoring-host-project     = var.project
-  server_hosts                = module.vf.server_urls
-  apiserver_hosts             = module.vf.apiserver_urls
-  adminapi_hosts              = module.vf.adminapi_urls
+  server_hosts = [
+    replace(module.vf.server_urls[0], "https://", "")
+  ]
+  apiserver_hosts = [
+    replace(module.vf.apiserver_urls[0], "https://", ""),
+  ]
+  adminapi_hosts = [
+    replace(module.vf.adminapi_urls[0], "https://", ""),
+  ]
   alert-notification-channels = {
     email = {
       labels = {


### PR DESCRIPTION
We still have an issue with 4 resources though. 

```
Error: Error creating AlertPolicy: googleapi: Error 400: Cannot find column or metadata name 'metric.result'.



Error: Error creating AlertPolicy: googleapi: Error 400: Could not find any metric named 'custom.googleapis.com/opencensus/en-verification-server/e2e/request_count'.



Error: Error creating Dashboard: googleapi: Error 400: Field gridLayout.widgets[1].xyChart.dataSets[0].timeSeriesQuery.timeSeriesQueryLanguage has an invalid value: Could not find any metric named 'custom.googleapis.com/opencensus/en-verification-server/api/issue/request_count'.
Field gridLayout.widgets[2].xyChart.dataSets[0].timeSeriesQuery.timeSeriesQueryLanguage has an invalid value: Cannot find column or metadata name 'metric.result'.



Error: Error creating Dashboard: googleapi: Error 400: Field gridLayout.widgets[0].xyChart.dataSets[0].timeSeriesQuery.timeSeriesQueryLanguage has an invalid value: Could not find any metric named 'custom.googleapis.com/opencensus/en-verification-server/e2e/request_count'.
Field gridLayout.widgets[1].xyChart.dataSets[0].timeSeriesQuery.timeSeriesQueryLanguage has an invalid value: Could not find any metric named 'custom.googleapis.com/opencensus/en-verification-server/e2e/request_count'.
Field gridLayout.widgets[2].xyChart.dataSets[0].timeSeriesQuery.timeSeriesQueryLanguage has an invalid value: Could not find any metric named 'custom.googleapis.com/opencensus/en-verification-server/e2e/request_latency'.
```

It's most likely caused by the observability exporters set to `NOOP`.