### PR TITLE
EFGSdownload fixing

### DIFF
--- a/builders/deploy.yaml
+++ b/builders/deploy.yaml
@@ -190,7 +190,7 @@ steps:
       - --trigger-http
       - --region=europe-west1
       - --runtime=go113
-      - --memory=128
+      - --memory=1024
       - --timeout=540s
       - --vpc-connector=${_VPC_CONNECTOR}
       - --egress-settings=private-ranges-only

--- a/builders/deploy.yaml
+++ b/builders/deploy.yaml
@@ -209,12 +209,30 @@ steps:
       - --trigger-http
       - --region=europe-west1
       - --runtime=go113
-      - --memory=256
+      - --memory=2048
       - --timeout=540s
       - --service-account=efgs-download-yesterdays-keys@${PROJECT_ID}.iam.gserviceaccount.com
       - --set-env-vars=PROJECT_ID=${PROJECT_ID}
       - --set-env-vars=EFGS_ENV=${_EFGS_ENV},EFGS_EXTENDED_LOGGING=${_EFGS_EXTENDED_LOGGING}
       - --set-env-vars=MAX_INTERVAL_AGE_ON_PUBLISH=${_MAX_INTERVAL_AGE_ON_PUBLISH},MAX_KEYS_ON_PUBLISH=${_MAX_KEYS_ON_PUBLISH},MAX_SAME_START_INTERVAL_KEYS=${_MAX_SAME_START_INTERVAL_KEYS}
+      - --set-env-vars=MAX_YESTERDAYS_KEYS_PART_SIZE=${_MAX_YESTERDAYS_KEYS_PART_SIZE}
+  - name: "gcr.io/cloud-builders/gcloud"
+    waitFor: ["-"]
+    args:
+      - functions
+      - deploy
+      - EfgsDownloadYesterdaysKeysPostponed
+      - --source=.
+      - --trigger-topic=efgs-postponed-yesterdays-downloading
+      - --region=europe-west1
+      - --runtime=go113
+      - --memory=2048
+      - --timeout=540s
+      - --service-account=efgs-download-yesterdays-keys@${PROJECT_ID}.iam.gserviceaccount.com
+      - --set-env-vars=PROJECT_ID=${PROJECT_ID}
+      - --set-env-vars=EFGS_ENV=${_EFGS_ENV},EFGS_EXTENDED_LOGGING=${_EFGS_EXTENDED_LOGGING}
+      - --set-env-vars=MAX_INTERVAL_AGE_ON_PUBLISH=${_MAX_INTERVAL_AGE_ON_PUBLISH},MAX_KEYS_ON_PUBLISH=${_MAX_KEYS_ON_PUBLISH},MAX_SAME_START_INTERVAL_KEYS=${_MAX_SAME_START_INTERVAL_KEYS}
+      - --set-env-vars=MAX_YESTERDAYS_KEYS_PART_SIZE=${_MAX_YESTERDAYS_KEYS_PART_SIZE}
   - name: "gcr.io/cloud-builders/gcloud"
     waitFor: ["-"]
     args:

--- a/functions.go
+++ b/functions.go
@@ -94,6 +94,11 @@ func EfgsDownloadYesterdaysKeys(w http.ResponseWriter, r *http.Request) {
 	efgs.DownloadAndSaveYesterdaysKeys(w, r)
 }
 
+// EfgsDownloadYesterdaysKeysPostponed Continues in downloading yesterdays key
+func EfgsDownloadYesterdaysKeysPostponed(ctx context.Context, m pubsub.Message) error {
+	return efgs.DownloadAndSaveYesterdaysKeysPostponed(ctx, m)
+}
+
 //EfgsImportKeys Imports given keys
 func EfgsImportKeys(ctx context.Context, m pubsub.Message) error {
 	return efgs.ImportKeysToKeyServer(ctx, m)

--- a/internal/functions/efgs/configuration.go
+++ b/internal/functions/efgs/configuration.go
@@ -41,18 +41,19 @@ type publishConfig struct {
 }
 
 type downloadConfig struct {
-	Env                      efgsutils.Environment
-	Client                   *http.Client
-	URL                      *urlutils.URL
-	NBTLSPair                *efgsutils.X509KeyPair
-	HaidMappings             map[string]string
-	PubSubClient             pubsub.EventPublisher
-	RedisClient              redis.Client
-	MutexManager             redismutex.MutexManager
-	RealtimeDBClient         *realtimedb.Client
-	MaxKeysOnPublish         int `env:"MAX_KEYS_ON_PUBLISH,default=30"`
-	MaxIntervalAge           int `env:"MAX_INTERVAL_AGE_ON_PUBLISH,default=15"`
-	MaxSameStartIntervalKeys int `env:"MAX_SAME_START_INTERVAL_KEYS,default=15"`
+	Env                               efgsutils.Environment
+	Client                            *http.Client
+	URL                               *urlutils.URL
+	NBTLSPair                         *efgsutils.X509KeyPair
+	HaidMappings                      map[string]string
+	PubSubClient                      pubsub.EventPublisher
+	RedisClient                       redis.Client
+	MutexManager                      redismutex.MutexManager
+	RealtimeDBClient                  *realtimedb.Client
+	MaxKeysOnPublish                  int `env:"MAX_KEYS_ON_PUBLISH,default=30"`
+	MaxIntervalAge                    int `env:"MAX_INTERVAL_AGE_ON_PUBLISH,default=15"`
+	MaxSameStartIntervalKeys          int `env:"MAX_SAME_START_INTERVAL_KEYS,default=15"`
+	MaxDownloadYesterdaysKeysPartSize int `env:"MAX_YESTERDAYS_KEYS_PART_SIZE"`
 }
 
 func loadUploadConfig(ctx context.Context) (*uploadConfig, error) {

--- a/internal/functions/efgs/constants/constants.go
+++ b/internal/functions/efgs/constants/constants.go
@@ -3,6 +3,9 @@ package constants
 //TopicNameImportKeys Topic for enqueuing keys to be imported.
 const TopicNameImportKeys = "efgs-import-keys"
 
+//TopicNameContinueYesterdayDownloading Topic for postponing download of yesterdays keys.
+const TopicNameContinueYesterdayDownloading = "efgs-postponed-yesterdays-downloading"
+
 //MutexNameDownloadAndSaveKeys Name for mutex for EFGS keys downloading.
 const MutexNameDownloadAndSaveKeys = "download-and-save-keys"
 

--- a/terraform/modules/erouska/notification.tf
+++ b/terraform/modules/erouska/notification.tf
@@ -9,3 +9,7 @@ resource "google_pubsub_topic" "user-registered" {
 resource "google_pubsub_topic" "efgs-import-keys" {
   name = "efgs-import-keys"
 }
+
+resource "google_pubsub_topic" "efgs-postponed-yesterdays-downloading" {
+  name = "efgs-postponed-yesterdays-downloading"
+}


### PR DESCRIPTION
Fixing/improving downloading of keys.

* Increased memory limits
* Empty batches are now skipped in ` DownloadAndSaveKeys`
* New function: `EfgsDownloadYesterdaysKeysPostponed`, triggered by topic `efgs-postponed-yesterdays-downloading`
* Postponing download of keys when there's too much of them in `DownloadAndSaveYesterdaysKeys`