### PR TITLE
EFGS: Fix isRecent filtering

### DIFF
--- a/builders/deploy.yaml
+++ b/builders/deploy.yaml
@@ -248,7 +248,7 @@ steps:
       - --service-account=efgs-import-keys@${PROJECT_ID}.iam.gserviceaccount.com
       - --set-env-vars=PROJECT_ID=${PROJECT_ID}
       - --set-env-vars=EFGS_ENV=${_EFGS_ENV},EFGS_EXTENDED_LOGGING=${_EFGS_EXTENDED_LOGGING}
-      - --set-env-vars=MAX_KEYS_ON_PUBLISH=${_MAX_KEYS_ON_PUBLISH}
+      - --set-env-vars=MAX_KEYS_ON_PUBLISH=${_MAX_KEYS_ON_PUBLISH},MAX_INTERVAL_AGE_ON_PUBLISH=${_MAX_INTERVAL_AGE_ON_PUBLISH}
       - --set-env-vars=KEY_SERVER_URL=${_KEY_SERVER_URL},VERIFICATION_SERVER_ADMIN_URL=${_VERIFICATION_SERVER_ADMIN_URL},VERIFICATION_SERVER_DEVICE_URL=${_VERIFICATION_SERVER_DEVICE_URL}
   - name: 'gcr.io/cloud-builders/gcloud'
     waitFor: ['-']

--- a/internal/functions/efgs/configuration.go
+++ b/internal/functions/efgs/configuration.go
@@ -38,6 +38,7 @@ type publishConfig struct {
 	KeyServer          *utils.KeyServerConfig
 	Client             *http.Client
 	MaxKeysOnPublish   int `env:"MAX_KEYS_ON_PUBLISH,default=30"`
+	MaxIntervalAge     int `env:"MAX_INTERVAL_AGE_ON_PUBLISH,default=15"`
 }
 
 type downloadConfig struct {

--- a/internal/functions/efgs/download-batch.go
+++ b/internal/functions/efgs/download-batch.go
@@ -286,7 +286,7 @@ func enqueueForImport(ctx context.Context, config *downloadConfig, keys []efgsap
 
 	for _, key := range keys {
 		// filter out keys that are too old
-		if !isRecent(&key, now, config.MaxIntervalAge) {
+		if !isRecent(key.RollingStartIntervalNumber, key.RollingPeriod, now, config.MaxIntervalAge) {
 			skippedKeys++
 			continue
 		}

--- a/internal/functions/efgs/keys-operations.go
+++ b/internal/functions/efgs/keys-operations.go
@@ -163,9 +163,9 @@ func signBatch(ctx context.Context, efgsEnv efgsutils.Environment, diagnosisKey 
 	return b64.StdEncoding.EncodeToString(detachedSignature), nil
 }
 
-func isRecent(k *efgsapi.DiagnosisKey, now time.Time, maxAge int) bool {
-	age := now.Unix() - int64(k.RollingStartIntervalNumber*600)
-	return age <= int64(maxAge)*24*int64(time.Hour.Seconds())
+func isRecent(interval uint32, period uint32, now time.Time, maxAgeDays int) bool {
+	minInterval := uint32(now.AddDate(0, 0, -maxAgeDays).Unix() / 600)
+	return interval+period > minInterval
 }
 
 func splitKeys(keys []efgsapi.ExpKey, batchSize int, maxOverlapping int) (batches []efgsapi.ExpKeyBatch) {


### PR DESCRIPTION
There may be quite a relevant delay between filtering of too-old keys in `EfgsDownload*Keys` and importing them in `EfgsImportKeys`. This is why we need to do the filtering once again right before the import.
One would think, why we can't filter the keys only once, when importing. We can but that would worsen number of generated batches for import so I think filtering them twice is the best, yet sad, solution.